### PR TITLE
+CHG: converted `CCD` class to a `dataclass` and removed `read_ccd_co…

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -35,11 +35,7 @@ instruments package
 
 
 .. automodule:: solary.instruments.camera
-    :special-members:
-    :exclude-members: __dict__, __weakref__
     :members:
-    :undoc-members:
-    :show-inheritance:
 
 .. automodule:: solary.instruments.optics
     :special-members:

--- a/solary/instruments/camera.py
+++ b/solary/instruments/camera.py
@@ -7,31 +7,11 @@ Script that contains miscellaneous functions and classes for / of camera system 
 import typing as t
 # Import standard libraries
 import json
+from pathlib import Path
+from dataclasses import dataclass
 
 
-def read_ccd_config(config_filepath: str) -> t.Dict[str, t.Any]:
-    """
-    Function to read the configuration file for a CCD system.
-
-    Parameters
-    ----------
-    config_filepath : str
-        File path of the configuration file.
-
-    Returns
-    -------
-    ccd_config : dict
-        CCD configuration.
-
-    """
-
-    # Open the file path and load / read it as a JSON
-    with open(config_filepath) as temp_obj:
-        ccd_config = json.load(temp_obj)
-
-    return ccd_config
-
-
+@dataclass
 class CCD:
     """
     Class that defines ande describes a CCD camera. Properties are derived from the user's input
@@ -52,44 +32,19 @@ class CCD:
 
     """
 
-    """
-    (Sphinx complains)
-    Static Properties
-    -----------------
-    chip_size : list
-        List with the size of the CCD chip in each dimension (x, y). Given in mm.
-    pixel_size_sq_m : float
-        Size of a single pixel, assuming a square shaped pixel. Given in m^2.
-    """
+    pixels: list  # type t.List[int, int]
+    pixel_size: float
+    dark_noise: float
+    readout_noise: float
+    full_well: t.Union[int, float]
+    quantum_eff: float
 
-    def __init__(self, ccd_config: t.Dict[str, t.Any]):
-        """
-        Init function.
-
-        Parameters
-        ----------
-        ccd_config : dict
-            CCD configuration dictionary.
-
-        Returns
-        -------
-        None.
-
-        """
-
-        # Placeholders for the static attributes
-        self.pixel_size = ccd_config["pixel_size"]  # type: float
-        self.pixels = ccd_config["pixels"]  # type: t.Tuple[float, float]
-        self.dark_noise = ccd_config["dark_noise"]  # type: float
-        self.readout_noise = ccd_config["readout_noise"]  # type: float
-        self.full_well = ccd_config["full_well"]  # type: float
-        self.quantum_eff = ccd_config["quantum_eff"]  # type: float
-
-        # Set the attributes dynamically in a for loop and set the values accordingly.
-        valid_keys = ['pixels', 'pixel_size', 'dark_noise', 'readout_noise', 'full_well',
-                      'quantum_eff']
-        for key in valid_keys:
-            setattr(self, key, ccd_config.get(key))
+    @staticmethod
+    def load(config_path: t.Union[Path, str]) -> "CCD":
+        """Factory method to construct a CCD object from a JSON file."""
+        with Path(config_path).open(mode="r") as temp_obj:
+            ccd_config = json.load(temp_obj)
+            return CCD(**ccd_config)
 
     @property
     def chip_size(self) -> t.Tuple[float, float]:

--- a/solary/instruments/telescope.py
+++ b/solary/instruments/telescope.py
@@ -130,7 +130,7 @@ class ReflectorCCD(Reflector, CCD):
 
         # Init the optics and camera classes accordingly
         Reflector.__init__(self, optics_config)
-        CCD.__init__(self, ccd_config)
+        CCD.__init__(self, **ccd_config)
 
         # Load the constants config file and get the photon flux (Given in m^-2 * s^-1)
         config = solary.auxiliary.config.get_constants()

--- a/tests/test_instruments/test_camera.py
+++ b/tests/test_instruments/test_camera.py
@@ -34,9 +34,9 @@ def fixture_ccd_test_config():
             '../' + test_paths_config['instruments_camera_ccd']['properties'])
 
     # Read and parse the CCD config file and return a dictionary with the properties
-    test_ccd_dict = solary.instruments.camera.read_ccd_config(test_ccd_path)
+    test_ccd_dict = solary.instruments.camera.CCD.load(test_ccd_path)
 
-    return test_ccd_dict
+    return test_ccd_dict.__dict__
 
 
 def test_read_ccd_config(ccd_test_config):
@@ -76,7 +76,7 @@ def test_ccd(ccd_test_config):
     """
 
     # Initiate the CCD class
-    test_ccd_class = solary.instruments.camera.CCD(ccd_test_config)
+    test_ccd_class = solary.instruments.camera.CCD(**ccd_test_config)
 
     # Check the config depending attributes
     assert test_ccd_class.pixels == ccd_test_config['pixels']
@@ -88,10 +88,8 @@ def test_ccd(ccd_test_config):
 
     # Check the first entry of the chip size. Multiply the number of pixels (x dimension) times the
     # pixel size in micro meters. Finally divide by 1000 to get a result in mm.
-    assert test_ccd_class.chip_size[0] == ccd_test_config['pixels'][0] \
-                                          * ccd_test_config['pixel_size'] / 1000.0
+    assert test_ccd_class.chip_size[0] == ccd_test_config['pixels'][0] * ccd_test_config['pixel_size'] / 1000.0
 
     # Check the size of a single pixel in m^2. The pixel size squared leads to micro meter squared.
     # Divide the results by 10^-12.
-    assert test_ccd_class.pixel_size_sq_m == (ccd_test_config['pixel_size'] ** 2.0) \
-                                             * 10.0 ** (-12.0)
+    assert test_ccd_class.pixel_size_sq_m == (ccd_test_config['pixel_size'] ** 2.0) * 10.0 ** (-12.0)

--- a/tests/test_instruments/test_telescope.py
+++ b/tests/test_instruments/test_telescope.py
@@ -46,9 +46,9 @@ def fixture_telescope_test_properties():
         solary.auxiliary.parse.get_test_file_path(
             '../' + test_paths_config['instruments_camera_ccd']['properties'])
 
-    test_ccd = solary.instruments.camera.read_ccd_config(test_ccd_path)
+    test_ccd = solary.instruments.camera.CCD.load(test_ccd_path)
 
-    return test_reflector, test_ccd
+    return test_reflector, test_ccd.__dict__
 
 
 def test_comp_fov():


### PR DESCRIPTION
You do not need to pull this just yet. Just look at the modifications and then we can discuss the changes made and the consequences to the existing code base. Using a `dataclass` is not necessary, you could also use the `__init__` method and add all the `dataclass` attributes as parameters. The point I'm trying to make is, be explicit in parameter passing to a function and avoid using a dictionary as the single input parameter to the class `__init__` method. Even if flake8 complains about too many parameters. You could always integrate the parameters into one or more data-structures. 