### PR TITLE
Refactor imports to avoid circular import errors

### DIFF
--- a/SolarY/__init__.py
+++ b/SolarY/__init__.py
@@ -1,12 +1,7 @@
 """TBW."""
 # flake8: noqa
-import os
-
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+from . import asteroid, auxiliary, general, instruments, neo
 
 __project__ = "SolarY"
 __author__ = "Dr.-Ing. Thomas Albin"
 __version__ = "deploy"
-
-# from . import tests
-from . import _config, asteroid, auxiliary, general, instruments, neo

--- a/SolarY/auxiliary/__init__.py
+++ b/SolarY/auxiliary/__init__.py
@@ -1,3 +1,4 @@
 """TBW."""
 # flake8: noqa
 from . import config, download, parse, reader
+from .config import root_dir

--- a/SolarY/auxiliary/config.py
+++ b/SolarY/auxiliary/config.py
@@ -1,9 +1,9 @@
 """Auxiliary functions for all library relevant configuration files."""
 import configparser
 import os
+from importlib import resources
 
-# Import the ROOT directory of SolarY
-from SolarY import ROOT_DIR
+ROOT_DIR = resources.import_module("SolarY").__path__[0]
 
 
 def get_constants() -> configparser.ConfigParser:

--- a/SolarY/auxiliary/config.py
+++ b/SolarY/auxiliary/config.py
@@ -1,9 +1,9 @@
 """Auxiliary functions for all library relevant configuration files."""
 import configparser
+import importlib
 import os
-from importlib import resources
 
-ROOT_DIR = resources.import_module("SolarY").__path__[0]
+root_dir = os.path.dirname(importlib.import_module("SolarY").__file__)
 
 
 def get_constants() -> configparser.ConfigParser:
@@ -20,7 +20,7 @@ def get_constants() -> configparser.ConfigParser:
     config = configparser.ConfigParser()
 
     # Get the constants ini file
-    constants_ini_path = os.path.join(ROOT_DIR, "_config", "constants.ini")
+    constants_ini_path = os.path.join(root_dir, "_config", "constants.ini")
 
     # Read and parse the config file
     config.read(constants_ini_path)
@@ -49,10 +49,10 @@ def get_paths(test: bool = False) -> configparser.ConfigParser:
     # Get the paths ini file, differentiate between prod and test
     if test:
         paths_ini_path = os.path.join(
-            ROOT_DIR, "../", "tests/_resources/_config", "test_paths.ini"
+            root_dir, "../", "tests/_resources/_config", "test_paths.ini"
         )
     else:
-        paths_ini_path = os.path.join(ROOT_DIR, "_config", "paths.ini")
+        paths_ini_path = os.path.join(root_dir, "_config", "paths.ini")
 
     # Read and parse the config file
     config.read(paths_ini_path)
@@ -82,7 +82,7 @@ def get_spice_kernels(ktype: str) -> configparser.ConfigParser:
     kernel_dict = {"generic": "generic.ini"}
 
     # Get the corresponding kernel config filepath
-    ini_path = os.path.join(ROOT_DIR, "_config", "SPICE", kernel_dict.get(ktype, ""))
+    ini_path = os.path.join(root_dir, "_config", "SPICE", kernel_dict.get(ktype, ""))
 
     # Read and parse the config file
     config.read(ini_path)

--- a/SolarY/auxiliary/parse.py
+++ b/SolarY/auxiliary/parse.py
@@ -84,7 +84,7 @@ def get_test_file_path(file_path: str) -> str:
         Absolute filepath to the testing file.
     """
     # Join the root directory of SolarY with the given filepath.
-    ROOT_DIR = resources.import_module("SolarY").__path__[0]
-    compl_test_file_path = os.path.join(ROOT_DIR, file_path)
+    root_dir = resources.import_module("SolarY").__path__[0]
+    compl_test_file_path = os.path.join(root_dir, file_path)
 
     return compl_test_file_path

--- a/SolarY/auxiliary/parse.py
+++ b/SolarY/auxiliary/parse.py
@@ -3,9 +3,7 @@ import hashlib
 import os
 import pathlib
 import typing as t
-
-# Get the ROOT DIR
-from SolarY import ROOT_DIR
+from importlib import resources
 
 
 def comp_md5(file_name: t.Union[str, pathlib.Path]) -> str:
@@ -86,6 +84,7 @@ def get_test_file_path(file_path: str) -> str:
         Absolute filepath to the testing file.
     """
     # Join the root directory of SolarY with the given filepath.
+    ROOT_DIR = resources.import_module("SolarY").__path__[0]
     compl_test_file_path = os.path.join(ROOT_DIR, file_path)
 
     return compl_test_file_path

--- a/SolarY/auxiliary/parse.py
+++ b/SolarY/auxiliary/parse.py
@@ -3,7 +3,8 @@ import hashlib
 import os
 import pathlib
 import typing as t
-from importlib import resources
+
+from .config import root_dir
 
 
 def comp_md5(file_name: t.Union[str, pathlib.Path]) -> str:
@@ -84,7 +85,7 @@ def get_test_file_path(file_path: str) -> str:
         Absolute filepath to the testing file.
     """
     # Join the root directory of SolarY with the given filepath.
-    root_dir = resources.import_module("SolarY").__path__[0]
+    # root_dir = os.path.dirname(importlib.import_module("SolarY").__file__)
     compl_test_file_path = os.path.join(root_dir, file_path)
 
     return compl_test_file_path

--- a/SolarY/general/astrodyn.py
+++ b/SolarY/general/astrodyn.py
@@ -2,7 +2,7 @@
 import math
 import typing as t
 
-import SolarY
+from .. import auxiliary as solary_auxiliary
 
 
 def tisserand(
@@ -59,7 +59,7 @@ def tisserand(
     if not sem_maj_axis_planet:
 
         # Get the constants config file
-        config = SolarY.auxiliary.config.get_constants()
+        config = solary_auxiliary.config.get_constants()
         sem_maj_axis_planet = float(config["planets"]["sem_maj_axis_jup"])
 
     # Compute the tisserand parameter

--- a/SolarY/general/photometry.py
+++ b/SolarY/general/photometry.py
@@ -2,7 +2,8 @@
 import math
 import typing as t
 
-import SolarY
+from .. import auxiliary as solary_auxiliary
+from . import vec
 
 
 def appmag2irr(app_mag: t.Union[int, float]) -> float:
@@ -35,7 +36,7 @@ def appmag2irr(app_mag: t.Union[int, float]) -> float:
     """
     # Load the configuration file that contains the zero point bolometric
     # irradiance
-    config = SolarY.auxiliary.config.get_constants()
+    config = solary_auxiliary.config.get_constants()
     appmag_irr_i0 = float(config["photometry"]["appmag_irr_i0"])
 
     # Convert apparent magnitude to irradiance
@@ -253,11 +254,11 @@ def hg_app_mag(
     vec_obj2ill = list(vec_obj2ill)
 
     # Compute the length of the two input vectors
-    vec_obj2obs_norm = SolarY.general.vec.norm(vec_obj2obs)
-    vec_obj2ill_norm = SolarY.general.vec.norm(vec_obj2ill)
+    vec_obj2obs_norm = vec.norm(vec_obj2obs)
+    vec_obj2ill_norm = vec.norm(vec_obj2ill)
 
     # Compute the phase angle of the asteroid
-    obj_phase_angle = SolarY.general.vec.phase_angle(vec_obj2obs, vec_obj2ill)
+    obj_phase_angle = vec.phase_angle(vec_obj2obs, vec_obj2ill)
 
     # Compute the reduced magnitude of the asteroid
     red_mag = reduc_mag(abs_mag, obj_phase_angle, slope_g)

--- a/SolarY/instruments/optics.py
+++ b/SolarY/instruments/optics.py
@@ -4,7 +4,7 @@ import json
 import typing as t
 from pathlib import Path
 
-import SolarY
+from ..general.geometry import circle_area
 
 
 class Reflector:
@@ -98,13 +98,13 @@ class Reflector:
             Main mirror area. Given in m^2.
         """
         # Call a sub-module that requires the radius as an input
-        return SolarY.general.geometry.circle_area(self.main_mirror_dia / 2.0)
+        return circle_area(self.main_mirror_dia / 2.0)
 
     @property
     def sec_mirror_area(self) -> float:
         """Get the secondary mirror area in m^2, assuming a circular shaped mirror."""
         # Call a sub-module that requires the radius as an input
-        return SolarY.general.geometry.circle_area(self.sec_mirror_dia / 2.0)
+        return circle_area(self.sec_mirror_dia / 2.0)
 
     @property
     def collect_area(self) -> float:

--- a/SolarY/instruments/telescope.py
+++ b/SolarY/instruments/telescope.py
@@ -10,8 +10,8 @@ import math
 import typing as t
 from pathlib import Path
 
-import SolarY
-
+from .. import auxiliary as solary_auxiliary
+from .. import general as solary_general
 from .camera import CCD
 from .optics import Reflector
 
@@ -92,7 +92,7 @@ class ReflectorCCD(Reflector, CCD):
         CCD.__init__(self, **ccd_config)
 
         # Load the constants config file and get the photon flux (Given in m^-2 * s^-1)
-        config = SolarY.auxiliary.config.get_constants()
+        config = solary_auxiliary.config.get_constants()
         self._photon_flux_v = float(config["photometry"]["photon_flux_V"])
         self._aperture = 0.0  # TODO: this should be passed in as an argument
         self._hfdia = 0.0  # TODO: this should be passed in as an argument
@@ -246,7 +246,7 @@ class ReflectorCCD(Reflector, CCD):
             Number of pixels within the aperture (rounded).
         """
         # Number of pixels corresponds to the aperture area (assuming a cirlce) divided by the iFOV
-        frac_pixels_in_aperture = SolarY.general.geometry.circle_area(
+        frac_pixels_in_aperture = solary_general.geometry.circle_area(
             0.5 * self.aperture
         ) / math.prod(self.ifov)
 
@@ -270,7 +270,7 @@ class ReflectorCCD(Reflector, CCD):
             Ratio of light within the photometric aperture. Value between 0 and 1.
         """
         # Compute the Gaussian standard deviation of the half flux diameter in arcsec
-        sigma = SolarY.general.geometry.fwhm2std(self.hfdia)
+        sigma = solary_general.geometry.fwhm2std(self.hfdia)
 
         # Compute the ratio, using the error function, the photometric aperture and half flux
         # diameter corresponding standard deviation
@@ -335,7 +335,7 @@ class ReflectorCCD(Reflector, CCD):
         """
         # First, convert the sky surface brightness to an integrated
         # brightness (apply the complete telescope's collection area)
-        total_sky_mag = SolarY.general.photometry.surmag2intmag(
+        total_sky_mag = solary_general.photometry.surmag2intmag(
             surmag=mag_arcsec_sq, area=math.prod(self.fov)
         )
         # Compute the number of electrons:

--- a/SolarY/neo/data.py
+++ b/SolarY/neo/data.py
@@ -1,8 +1,5 @@
 """NEO data download, parsing and database creation functions are part of this sub-module."""
 import gzip
-
-# import urllib.parse
-# import urllib.request
 import os
 import re
 import shutil
@@ -13,10 +10,11 @@ from pathlib import Path
 
 import requests
 
-import SolarY
+from .. import auxiliary as solary_auxiliary
+from .. import general as solary_general
 
 # Get the file paths
-PATH_CONFIG = SolarY.auxiliary.config.get_paths()
+PATH_CONFIG = solary_auxiliary.config.get_paths()
 
 
 def _get_neodys_neo_nr() -> int:
@@ -79,7 +77,7 @@ def download(row_exp: t.Optional[bool] = None) -> t.Tuple[str, t.Optional[int]]:
     -1- Link to the NEODyS data: https://newton.spacedys.com/neodys/index.php?pc=1.0
     """
     # Set the complete filepath. The file is stored in the user's home directory
-    download_filename = SolarY.auxiliary.parse.setnget_file_path(
+    download_filename = solary_auxiliary.parse.setnget_file_path(
         PATH_CONFIG["neo"]["neodys_raw_dir"], PATH_CONFIG["neo"]["neodys_raw_file"]
     )
 
@@ -127,7 +125,7 @@ def read_neodys() -> t.List[t.Dict[str, t.Any]]:
         List of dictionaries that contains the NEO data from the NEODyS download.
     """
     # Set the download file path. The file shall be stored in the home direoctry
-    path_filename = SolarY.auxiliary.parse.setnget_file_path(
+    path_filename = solary_auxiliary.parse.setnget_file_path(
         PATH_CONFIG["neo"]["neodys_raw_dir"], PATH_CONFIG["neo"]["neodys_raw_file"]
     )
 
@@ -207,7 +205,7 @@ class NEOdysDatabase:
             The default is False.
         """
         # Set / Get an SQLite database path + filename
-        self.db_filename = SolarY.auxiliary.parse.setnget_file_path(
+        self.db_filename = solary_auxiliary.parse.setnget_file_path(
             PATH_CONFIG["neo"]["neodys_db_dir"], PATH_CONFIG["neo"]["neodys_db_file"]
         )
 
@@ -315,10 +313,10 @@ class NEOdysDatabase:
             _neo_deriv_param_dict.append(
                 {
                     "Name": _neo_data_line_f[0],
-                    "Aphel_AU": SolarY.general.astrodyn.kep_apoapsis(
+                    "Aphel_AU": solary_general.astrodyn.kep_apoapsis(
                         sem_maj_axis=_neo_data_line_f[1], ecc=_neo_data_line_f[2]
                     ),
-                    "Perihel_AU": SolarY.general.astrodyn.kep_periapsis(
+                    "Perihel_AU": solary_general.astrodyn.kep_periapsis(
                         sem_maj_axis=_neo_data_line_f[1], ecc=_neo_data_line_f[2]
                     ),
                 }
@@ -362,7 +360,7 @@ def download_granvik2018() -> str:
     -2- https://www.mv.helsinki.fi/home/mgranvik/data/Granvik+_2018_Icarus/
     """
     # Set the download path to the home directory
-    download_filename = SolarY.auxiliary.parse.setnget_file_path(
+    download_filename = solary_auxiliary.parse.setnget_file_path(
         PATH_CONFIG["neo"]["granvik2018_raw_dir"],
         PATH_CONFIG["neo"]["granvik2018_raw_file"],
     )
@@ -392,7 +390,7 @@ def download_granvik2018() -> str:
     os.remove(downl_file_path)
 
     # Compute the MD5 hash
-    md5_hash = SolarY.auxiliary.parse.comp_md5(unzip_file_path)
+    md5_hash = solary_auxiliary.parse.comp_md5(unzip_file_path)
 
     return md5_hash
 
@@ -410,7 +408,7 @@ def read_granvik2018() -> t.List[t.Dict[str, t.Any]]:
         List of dictionaries that contains the NEO data from the downloaded model data.
     """
     # Set the download path of the model file
-    path_filename = SolarY.auxiliary.parse.setnget_file_path(
+    path_filename = solary_auxiliary.parse.setnget_file_path(
         PATH_CONFIG["neo"]["granvik2018_raw_dir"],
         PATH_CONFIG["neo"]["granvik2018_unzip_file"],
     )
@@ -488,7 +486,7 @@ class Granvik2018Database:
             directory. The default is False.
         """
         # Set the database path to the home directory
-        self.db_filename = SolarY.auxiliary.parse.setnget_file_path(
+        self.db_filename = solary_auxiliary.parse.setnget_file_path(
             PATH_CONFIG["neo"]["granvik2018_db_dir"],
             PATH_CONFIG["neo"]["granvik2018_db_file"],
         )
@@ -585,10 +583,10 @@ class Granvik2018Database:
             _neo_deriv_param_dict.append(
                 {
                     "ID": _neo_data_line_f[0],
-                    "Aphel_AU": SolarY.general.astrodyn.kep_apoapsis(
+                    "Aphel_AU": solary_general.astrodyn.kep_apoapsis(
                         sem_maj_axis=_neo_data_line_f[1], ecc=_neo_data_line_f[2]
                     ),
-                    "Perihel_AU": SolarY.general.astrodyn.kep_periapsis(
+                    "Perihel_AU": solary_general.astrodyn.kep_periapsis(
                         sem_maj_axis=_neo_data_line_f[1], ecc=_neo_data_line_f[2]
                     ),
                 }

--- a/tests/test_asteroid/test_physp.py
+++ b/tests/test_asteroid/test_physp.py
@@ -9,7 +9,7 @@ Testing suite for solary/asteroid/physp
 import pytest
 
 # Import solary
-import SolarY
+import SolarY.asteroid
 
 
 def test_ast_size():

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,9 @@ deps =
   pylint>=1.8
   -rrequirements.txt
 commands =
-  pylint --disable=W0511,C0103,R0913,C0304,C0413 --output-format=colorized SolarY
+  # C0103 =>  Module name "SolarY" doesn't conform to snake_case naming style (invalid-name)
+  # W0511 => warns about TODO comments.
+  pylint --disable=W0511,C0103 --max-args=7 --output-format=colorized SolarY
 
 
 [testenv:detect_duplicate]

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ deps =
   pylint>=1.8
   -rrequirements.txt
 commands =
-  pylint --disable=W0511,R0401,C0103,R0913,C0304,C0413 --output-format=colorized SolarY
+  pylint --disable=W0511,C0103,R0913,C0304,C0413 --output-format=colorized SolarY
 
 
 [testenv:detect_duplicate]


### PR DESCRIPTION
In the libarary source code ``import Solary`` should be avoided at all costs. This will always lead to circular import warnings / errors (later). Instead, use the relative import mechanism and only import what is need in a particular sub-package module. 

For example in telescope.py,

```
from .. import auxiliary as solary_auxiliary
from .. import general as solary_general
from .camera import CCD
from .optics import Reflector
```

Any users of this library are allowed to use ``import SolarY``, as well as in the ``SolarY/tests`` directory.
